### PR TITLE
Add Hardcore mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ workque --yesterday
 # This will jump back to Friday's note if it's Monday today!
 ```
 
+If you're kind of nerd and you have no life. You would rather work over the weekend than hanging out with folks, so you should enable the **hardcore** mode which will stop skipping weekend for you.
+
+Add this to your `.bash_profile`
+
+```sh
+export WORQUE_HARDCORE=true
+```
+
 You can also explicitly specify the file path
 
 ```sh

--- a/bin/worque
+++ b/bin/worque
@@ -18,7 +18,7 @@ Worque.configure do |config|
     end
 
     opts.on("--yesterday", "Create and return the file name") do
-      config[:mode] = :yesterday
+      config[:mode] = config[:hardcore] ? :yesterday_hardcore : :yesterday
     end
 
     opts.on("-pPATH", "--path PATH", "Path to your notes directory") do |path|

--- a/lib/worque.rb
+++ b/lib/worque.rb
@@ -8,7 +8,8 @@ module Worque
   def configs
     @configs ||= {
       path: ENV['WORQUE_PATH'],
-      mode: :today
+      mode: :today,
+      hardcore: ENV['WORQUE_HARDCORE'].downcase == 'true'
     }
   end
 

--- a/lib/worque/business_day.rb
+++ b/lib/worque/business_day.rb
@@ -10,7 +10,15 @@ module Worque
       shift(date, -1)
     end
 
+    def previous_continuous(date)
+      shift_continuous(date, -1)
+    end
+
     private
+
+    def shift_continuous(date, inc)
+      date += inc
+    end
 
     def shift(date, inc)
       loop do

--- a/lib/worque/command.rb
+++ b/lib/worque/command.rb
@@ -10,6 +10,8 @@ module Worque
                filename(path, Date.today)
              when :yesterday
                filename(path, Worque::BusinessDay.previous(Date.today))
+             when :yesterday_hardcore
+               filename(path, Worque::BusinessDay.previous_continuous(Date.today))
              end
       touch file
       return file

--- a/test/worque_test.rb
+++ b/test/worque_test.rb
@@ -1,4 +1,6 @@
 require 'test_helper'
+require 'date'
+require 'worque/business_day'
 
 class WorqueTest < Minitest::Test
   def test_that_it_has_a_version_number
@@ -7,5 +9,15 @@ class WorqueTest < Minitest::Test
 
   def test_it_does_something_useful
     assert true
+  end
+
+  def test_that_business_day_previous_continuous_dont_skip_sunday
+    sunday = Worque::BusinessDay.previous_continuous(Date.new(2016,7,18)) # 07/18/2016 is Monday
+    assert sunday.wday == 0
+  end
+
+  def test_that_business_day_previous_skip_sunday
+    friday = Worque::BusinessDay.previous(Date.new(2016,7,18)) # 07/18/2016 is Monday
+    assert friday.wday == 5
   end
 end


### PR DESCRIPTION
Implement `hardcore` mode as mentioned in #1 

Hardcore mode is enabled by setting in the `~/.bash_profile`:

``` sh
export WORQUE_HARDCORE=true
```

When this mode is enabled, it will not skip the weekend anymore.
