### PR TITLE
system-wide accessibility via RVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Install it by
 
     $ gem install worque
 
+Or, if you're using RVM and want the command available system-wide while keeping it in its own gemset
+
+    $ rvm default@worque --create do gem install worque
+    $ rvm wrapper default@worque --no-prefix worque
+
 ## Quick start guide
 
 ### CLI


### PR DESCRIPTION
The first command creates a new gemset named `worque` in your default Ruby version, and installs worque into it.
The second command exposes the `worque` command that's in the gemset to the rest of your system, so you don't need to be in the gemset in order to use the command.
