### PR TITLE
Add task directly from terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ You can also explicitly specify the file path
 worque todo --for today --path ~/path/to/your/notes
 ```
 
+Moreover, you can add a task into your notes quickly without open that file.
+```sh
+worque todo --for today --append-task "Your task"
+```
+
 It's chain-able with other commands
 
 ```sh
@@ -146,4 +151,3 @@ Bug reports and pull requests are welcome on GitHub at [https://github.com/huynh
 
 The gem is available as open source under the terms of the
 [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/worque/cli.rb
+++ b/lib/worque/cli.rb
@@ -13,7 +13,7 @@ module Worque
     method_option :for, force: false, type: :string, enum: ['today', 'yesterday'], default: 'today'
     method_option :skip_weekend, force: false, type: :boolean, default: true
     method_option :path, force: false, type: :string, default: ENV['WORQUE_PATH']
-    method_option :task, force: false, type: :string
+    method_option :append_task, force: false, type: :string
 
     def todo
       $stdout.puts Worque::Command::Todo.run(options)

--- a/lib/worque/cli.rb
+++ b/lib/worque/cli.rb
@@ -13,6 +13,7 @@ module Worque
     method_option :for, force: false, type: :string, enum: ['today', 'yesterday'], default: 'today'
     method_option :skip_weekend, force: false, type: :boolean, default: true
     method_option :path, force: false, type: :string, default: ENV['WORQUE_PATH']
+    method_option :task, force: false, type: :string
 
     def todo
       $stdout.puts Worque::Command::Todo.run(options)

--- a/lib/worque/command/todo.rb
+++ b/lib/worque/command/todo.rb
@@ -17,8 +17,8 @@ module Worque
           Worque::Utils::Command.touch f
         end
 
-        if options.task
-          Worque::Utils::Command.append_text(notes_file_path, options.task)
+        if options.append_task
+          Worque::Utils::Command.append_text(notes_file_path, options.append_task)
         end
 
         notes_file_path

--- a/lib/worque/command/todo.rb
+++ b/lib/worque/command/todo.rb
@@ -12,9 +12,16 @@ module Worque
       def call
         Worque::Utils::Command.mkdir(options.path)
 
-        filename(date_for).tap do |f|
+        notes_file_path = filename(date_for)
+        notes_file_path.tap do |f|
           Worque::Utils::Command.touch f
         end
+
+        if options.task
+          Worque::Utils::Command.append_text(notes_file_path, options.task)
+        end
+
+        notes_file_path
       end
 
       def self.run(options)

--- a/lib/worque/command/todo/options.rb
+++ b/lib/worque/command/todo/options.rb
@@ -6,14 +6,14 @@ module Worque
     class Todo::Options
       attr_accessor :path
       attr_accessor :for
-      attr_accessor :task
+      attr_accessor :append_task
       attr_writer :skip_weekend
 
       def initialize(opts)
         @path = opts[:path]
         @skip_weekend = opts[:skip_weekend]
         @for = opts[:for]
-        @task = opts[:task]
+        @append_task = opts[:append_task]
       end
 
       def skip_weekend?

--- a/lib/worque/command/todo/options.rb
+++ b/lib/worque/command/todo/options.rb
@@ -6,12 +6,14 @@ module Worque
     class Todo::Options
       attr_accessor :path
       attr_accessor :for
+      attr_accessor :task
       attr_writer :skip_weekend
 
       def initialize(opts)
         @path = opts[:path]
         @skip_weekend = opts[:skip_weekend]
         @for = opts[:for]
+        @task = opts[:task]
       end
 
       def skip_weekend?

--- a/lib/worque/utils/command.rb
+++ b/lib/worque/utils/command.rb
@@ -12,6 +12,12 @@ module Worque
       def touch(path)
         FileUtils.touch(path)
       end
+
+      def append_text(path, text)
+        File.open(path, 'a') { |f|
+          f.puts "#{text}\n"
+        }
+      end
     end
   end
 end

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -55,7 +55,7 @@ describe Worque do
     it 'append task to notes' do
       date = Date.new(2016, 7, 24)
       Timecop.freeze(date) do
-        ARGV.replace %w[todo --task "foo"]
+        ARGV.replace %w[todo --append-task "foo"]
         Worque::CLI.start
         assert_equal("tmp/for/test/notes-2016-07-24.md\n", $stdout.string)
       end

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -57,7 +57,7 @@ describe Worque do
       Timecop.freeze(date) do
         ARGV.replace %w[todo --task "foo"]
         Worque::CLI.start
-        assert_equal($stdout.string, "tmp/for/test/notes-2016-07-24.md\n")
+        assert_equal("tmp/for/test/notes-2016-07-24.md\n", $stdout.string)
       end
     end
   end

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -11,7 +11,7 @@ describe Worque do
     before do
       $stdout = StringIO.new
     end
-    
+
     after do
       system "rm -rf tmp/*"
     end
@@ -49,6 +49,15 @@ describe Worque do
         ARGV.replace %w[todo --for yesterday --no-skip-weekend]
         Worque::CLI.start
         assert_equal($stdout.string, "tmp/for/test/notes-2016-07-17.md\n")
+      end
+    end
+
+    it 'append task to notes' do
+      date = Date.new(2016, 7, 24)
+      Timecop.freeze(date) do
+        ARGV.replace %w[todo --task "foo"]
+        Worque::CLI.start
+        assert_equal($stdout.string, "tmp/for/test/notes-2016-07-24.md\n")
       end
     end
   end

--- a/test/lib/worque/command/todo_test.rb
+++ b/test/lib/worque/command/todo_test.rb
@@ -29,7 +29,7 @@ describe Worque::Command::Todo do
 
     describe 'when mode is adding task' do
       it 'append task title to notes' do
-        options = { path: 'tmp/hello/word', for: 'today', task: 'foo' }
+        options = { path: 'tmp/hello/word', for: 'today', append_task: 'foo' }
 
         Timecop.freeze(Date.new(2016, 7, 24)) do
           Worque::Command::Todo.run(options)

--- a/test/lib/worque/command/todo_test.rb
+++ b/test/lib/worque/command/todo_test.rb
@@ -26,5 +26,18 @@ describe Worque::Command::Todo do
         end
       end
     end
+
+    describe 'when mode is adding task' do
+      it 'append task title to notes' do
+        options = { path: 'tmp/hello/word', for: 'today', task: 'foo' }
+
+        Timecop.freeze(Date.new(2016, 7, 24)) do
+          Worque::Command::Todo.run(options)
+
+          assert File.exists?("#{options[:path]}/notes-2016-07-24.md")
+          assert File.readlines("#{options[:path]}/notes-2016-07-24.md").grep(/foo/).any?
+        end
+      end
+    end
   end
 end

--- a/test/lib/worque/utils/command_test.rb
+++ b/test/lib/worque/utils/command_test.rb
@@ -40,5 +40,18 @@ describe Worque::Utils::Command do
       assert File.exists?(path)
     end
   end
-end
 
+  describe '.append_text' do
+    it 'append text to file' do
+      dir = 'tmp'
+      @helper.mkdir(dir)
+
+      path = 'tmp/text.txt'
+      @helper.touch(path)
+
+      text = 'foo'
+      @helper.append_text(path, text)
+      assert File.readlines(path).grep(/#{text}/).any?
+    end
+  end
+end


### PR DESCRIPTION
Implement adding task directly from terminal.

Example:

`worque todo --task "Make pull request"`

Task `"Make pull request"` will be append to the end of current notes file.
