### PR TITLE
Extract file_path format in report_file_path method

### DIFF
--- a/lib/worque/command/push/action.rb
+++ b/lib/worque/command/push/action.rb
@@ -6,6 +6,8 @@ module Worque
   module Command
     module Push
       class Action
+        REPORT_FILE_PATH_FORMAT = "%<worque_path>s/notes-%<date_for>s.md".freeze
+
         def initialize(options)
           @options = options
         end
@@ -41,7 +43,10 @@ module Worque
         end
 
         def report_file_path
-          "#{ ENV['WORQUE_PATH'] }/notes-#{date_for}.md"
+          REPORT_FILE_PATH_FORMAT % Hash[
+            worque_path: ENV['WORQUE_PATH'],
+            date_for: date_for
+          ]
         end
       end
     end


### PR DESCRIPTION
This PR extracts `file_path` format of push action to a constant, it make the code more readable, also easier to change the string format later.

With ❤️ 
